### PR TITLE
Wallet.prototype.transfers

### DIFF
--- a/lib/wallet.js
+++ b/lib/wallet.js
@@ -42,10 +42,10 @@ Wallet.prototype._request = function (body) {
                 }
             });
         });
-        req.on('error', (e) => resolve(e));
-        req.write(requestJSON);
-        req.end();
-    });
+            req.on('error', (e) => resolve(e));
+            req.write(requestJSON);
+            req.end();
+        });
 
     return requestPromise;
 };
@@ -144,6 +144,37 @@ Wallet.prototype.incomingTransfers = function(type) {
     let method = 'incoming_transfers';
     let params = {};
     params.transfer_type = type;
+    return this._body(method, params);
+};
+// bool in;
+// bool out;
+// bool pending;
+// bool failed;
+// bool pool;
+
+// bool filter_by_height;
+// uint64_t min_height;
+// uint64_t max_height;
+Wallet.prototype.transfers = function(_in, out, pending, failed, pool) {
+    let method = 'get_transfers';
+    let params = {};
+
+    if(_in === true) {
+        params['in'] = true;
+    }
+    if(out === true) {
+        params['out'] = true;
+    }
+    if(pending === true) {
+        params['pending'] = true;
+    }
+    if(failed === true) {
+        params['failed'] = true;
+    }
+    if(pool === true) {
+        params['pool'] = true;
+    }
+
     return this._body(method, params);
 };
 


### PR DESCRIPTION
Support for `get_transfers` RPC method. It's undocumented, I will open a PR on `monero-site` for this.

This is related to https://github.com/PsychicCat/monero-nodejs/pull/6

Sorry about the whitespace changes, I'll remove them, should I rebase.