### PR TITLE
Using `fetch` for RPC requests

### DIFF
--- a/lib/wallet.js
+++ b/lib/wallet.js
@@ -1,5 +1,5 @@
 'use strict';
-var request = require('request');
+var fetch = self.fetch || require('node-fetch');
 var Utilities = require('../lib/utilities');
 
 class Wallet {
@@ -118,32 +118,37 @@ class Wallet {
 
 // private method for making RPC requests
 function _request(self) {
+    let body = {
+        jsonrpc: '2.0',
+        id: '0',
+        method: self.method,
+        params: self.params
+    };
     let options = {
-        url: `http://${self.hostname}:${self.port}/json_rpc`,
         method: 'POST',
-        json: true,
         headers: {'Content-Type': 'application/json'},
-        body: {
-            jsonrpc: '2.0',
-            id: '0',
-            method: self.method,
-            params: self.params
-        }
+        body: JSON.stringify(body)
     };
 
     return new Promise((resolve, reject) => {
-        request(options, function (err, res, body) {
-            if (err) {
-                reject(err);
-            } else if (body && body.result) {
-                resolve(body.result);
-            } else if (body && body.error) {
-                reject(body.error);
+        fetch(`http://${self.hostname}:${self.port}/json_rpc`, options)
+        .then((response) => {
+            if(response.ok) {
+                response.json().then((json) => {
+                    if (json && json.result) {
+                        resolve(json.result);
+                    } else if (json && json.error) {
+                        reject(json.error);
+                    } else {
+                        reject(response);
+                    }
+                })
             } else {
-                resolve(body);
+                reject(response);
             }
-        });
-    })
+        })
+        .catch(reject);
+    });
 }
 
 module.exports = Wallet;

--- a/lib/wallet.js
+++ b/lib/wallet.js
@@ -1,5 +1,5 @@
 'use strict';
-var fetch = self.fetch || require('node-fetch');
+var fetch = (typeof self === 'undefined' || self.fetch) || require('node-fetch');
 var Utilities = require('../lib/utilities');
 
 class Wallet {

--- a/lib/wallet.js
+++ b/lib/wallet.js
@@ -142,6 +142,9 @@ function _request(self) {
         headers: {'Content-Type': 'application/json'},
         body: JSON.stringify(body)
     };
+    
+    self.method = undefined;
+    self.params = {};
 
     return new Promise((resolve, reject) => {
         fetch(`${self.protocol}://${self.hostname}:${self.port}/json_rpc`, options)

--- a/lib/wallet.js
+++ b/lib/wallet.js
@@ -3,9 +3,10 @@ var fetch = (typeof self === 'undefined' || self.fetch) || require('node-fetch')
 var Utilities = require('../lib/utilities');
 
 class Wallet {
-    constructor(hostname, port) {
+    constructor(hostname, port, secure) {
         this.hostname = hostname || '127.0.0.1';
         this.port = port || 18082;
+        this.protocol = secure === true ? 'https' : 'http';
         this.params = {};
     }
 
@@ -131,7 +132,7 @@ function _request(self) {
     };
 
     return new Promise((resolve, reject) => {
-        fetch(`http://${self.hostname}:${self.port}/json_rpc`, options)
+        fetch(`${self.protocol}://${self.hostname}:${self.port}/json_rpc`, options)
         .then((response) => {
             if(response.ok) {
                 response.json().then((json) => {

--- a/lib/wallet.js
+++ b/lib/wallet.js
@@ -1,5 +1,5 @@
 'use strict';
-var fetch = (typeof self === 'undefined' || self.fetch) || require('node-fetch');
+require('isomorphic-fetch');
 var Utilities = require('../lib/utilities');
 
 class Wallet {

--- a/lib/wallet.js
+++ b/lib/wallet.js
@@ -79,7 +79,9 @@ class Wallet {
     }
 
     splitIntegratedAddress(address) {
-        return _request('split_integrated_address', {integrated_address: address});
+        this.method = 'split_integrated_address';
+        this.params.integrated_address = address;
+        return _request(this);
     }
 
     store() {

--- a/lib/wallet.js
+++ b/lib/wallet.js
@@ -92,6 +92,16 @@ class Wallet {
         return _request('stop_wallet');
     }
 
+    makeUri(address, amount, paymentId, recipientName, txDescription) {
+        this.method = 'make_uri';
+        this.params.address = address,
+        this.params.amount = amount,
+        this.params.payment_id = paymentId,
+        this.params.recipient_name = recipientName,
+        this.params.tx_description = txDescription
+        return _request(this)
+    }
+
     transfer(destinations, options = {}, method = 'transfer') {
         if (Array.isArray(destinations)) {
             destinations.forEach((dest) => dest.amount = Utilities.toAtomic(dest.amount));

--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
   "homepage": "https://github.com/PsychicCat/monero-nodejs#readme",
   "dependencies": {
     "big.js": "^3.1.3",
-    "random-js": "^1.0.8",
-    "request": "^2.79.0"
+    "node-fetch": "^1.6.3",
+    "random-js": "^1.0.8"
   },
   "devDependencies": {
     "dotenv": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "homepage": "https://github.com/PsychicCat/monero-nodejs#readme",
   "dependencies": {
     "big.js": "^3.1.3",
-    "node-fetch": "^1.6.3",
+    "isomorphic-fetch": "^2.2.1",
     "random-js": "^1.0.8"
   },
   "devDependencies": {


### PR DESCRIPTION
This replaces #6 

I tried rebasing my code onto `dev-v10`, but had difficulties with webpack and `request` being a node-only library. So I thought why not completely switch to `fetch` for making RPC calls, and this is what I came up with. Works in both node.js and the browser using webpack.