### PR TITLE
Fix checking for destinations array

### DIFF
--- a/lib/wallet.js
+++ b/lib/wallet.js
@@ -81,7 +81,7 @@ Wallet.prototype.address = function() {
 // transfer Monero to a single recipient, or a group of recipients
 Wallet.prototype.transfer = function(destinations, options) {
     if(typeof options === 'undefined') options = {};
-    if(typeof destinations === 'array') {
+    if(Array.isArray(destinations)) {
         destinations.forEach((dest) => dest.amount = convert(dest.amount));
     } else {
         destinations.amount = convert(destinations.amount);
@@ -100,7 +100,7 @@ Wallet.prototype.transfer = function(destinations, options) {
 // split a transfer into more than one tx if necessary
 Wallet.prototype.transferSplit = function(destinations, options) {
     if(typeof options === 'undefined') options = {};
-    if(typeof destinations === 'array') {
+    if(Array.isArray(destinations)) {
         destinations.forEach((dest) => dest.amount = convert(dest.amount));
     } else {
         destinations.amount = convert(destinations.amount);


### PR DESCRIPTION
`typeof destinations === 'array'` no longer works as the type is 'object'