### PR TITLE
RPC authentication, new wallet management methods, and sweep_all

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,12 @@ Parameters:
         {   
             mixin: (*number*), // amount of existing transaction outputs to mix yours with (default is 4)
             unlockTime: (*number*), // number of blocks before tx is spendable (default is 0)
-            pid: (*string*) // optional payment ID (a 64 character hexadecimal string used for identifying the sender of a payment) 
+            pid: (*string*) // optional payment ID (a 64 character hexadecimal string used for identifying the sender of a payment)
+            payment_id: (*string*) // optional payment ID (a 64 character hexadecimal string used for identifying the sender of a payment)
+            do_not_relay: (*boolean*) // optional boolean used to indicate whether a transaction should be relayed or not
+            priority: (*integer*) // optional transaction priority
+            get_tx_hex: (*boolean*) // optional boolean used to indicate that the transaction should be returned as hex string after sending
+            get_tx_key: (*boolean*) // optional boolean used to indicate that the transaction key should be returned after sending
         }
 
 Example response:

--- a/README.md
+++ b/README.md
@@ -64,6 +64,51 @@ To run the tests, clone the repository and then:
 
 ## Wallet Methods
 
+### create_wallet
+Usage:
+
+```
+Wallet.create_wallet('monero_wallet', '', 'English');
+```
+
+Creates a new wallet.
+    
+Parameters:
+
+* `filename` - filename of wallet to create (*string*)
+* `password` - wallet password (*string*)
+* `language` - language to use for mnemonic phrase (*string*)
+
+Example response: 
+
+```
+{}
+```
+
+Returns an object with `error` field if unsuccessful.
+
+### open_walllet
+Usage:
+
+```
+Wallet.open_wallet('monero_wallet', '');
+```
+
+Opens a wallet.
+    
+Parameters:
+
+* `filename` - filename of wallet to open (*string*)
+* `password` -wallet password (*string*)
+
+Example response: 
+
+```
+{}
+```
+
+Returns an object with `error` field if unsuccessful.
+
 ### balance
 Usage:
 
@@ -144,14 +189,29 @@ Example response:
 { tx_hash_list: [ '<f17fb226ebfdf784a0f5814e1c5bb78c19ea26930a0d706c9dc1085a250ceb37>' ] }
 ```
 
-### sweep
+### sweep_dust
 Usage:
 
 ```
-Wallet.sweep();
+Wallet.sweep_dust();
 ```
 
 Sends all dust outputs back to the wallet, to make funds easier to spend and mix. Responds with a list of the corresponding transaction hashes.
+
+Example response:
+
+```
+{ tx_hash_list: [ '<75c666fc96120a643321a5e76c0376b40761582ee40cc4917e8d1379a2c8ad9f>' ] }
+```
+
+### sweep_all
+Usage:
+
+```
+Wallet.sweep_all('47Vmj6BXSRPax69cVdqVP5APVLkcxxjjXdcP9fJWZdNc5mEpn3fXQY1CFmJDvyUXzj2Fy9XafvUgMbW91ZoqwqmQ6RjbVtp');
+```
+
+Sends all spendable outputs to the specified address. Responds with a list of the corresponding transaction hashes.
 
 Example response:
 

--- a/example.js
+++ b/example.js
@@ -3,33 +3,18 @@ var Wallet = new moneroWallet();
 
 // examples
 
-// Wallet.integratedAddress().then(function(result){
-//     console.log(result);
-// });
-
-// Wallet.balance().then(function(response){
-//     console.log(response);
-// });
-//
-// Wallet.address().then(function(response){
-//     console.log(response);
-// });
-//
-// Wallet.height().then(function(height){
-//     console.log(height);
-// });
-//
-Wallet.incomingTransfers('all').then(function(result){
+Wallet.create_wallet('monero_wallet').then(function(result){
     console.log(result);
 });
 
-//var destination = {};
-//destination.address = '47Vmj6BXSRPax69cVdqVP5APVLkcxxjjXdcP9fJWZdNc5mEpn3fXQY1CFmJDvyUXzj2Fy9XafvUgMbW91ZoqwqmQ6RjbVtp';
-//destination.amount = 1;
-//
-//Wallet.transfer(destination).then(function(result){
-//    console.log(result);
-//});
+Wallet.open_wallet('monero_wallet').then((result) => {
+    console.log(result);
+});
 
+Wallet.address().then((result) => {
+    console.log(result);
+});
 
-
+Wallet.balance().then((result) => {
+    console.log(result);
+});

--- a/lib/wallet.js
+++ b/lib/wallet.js
@@ -124,9 +124,16 @@ Wallet.prototype.transferSplit = function(destinations, options) {
 };
 
 // send all dust outputs back to the wallet with 0 mixin
-Wallet.prototype.sweep = function() {
+Wallet.prototype.sweep_dust = function() {
     let method = 'sweep_dust';
     return this._body(method);
+};
+
+// send all dust outputs back to the wallet with 0 mixin
+Wallet.prototype.sweep_all = function(address) {
+    let method = 'sweep_all';
+    let params = {address: address};
+    return this._body(method, params);
 };
 
 // get a list of incoming payments using a given payment ID

--- a/lib/wallet.js
+++ b/lib/wallet.js
@@ -37,16 +37,43 @@ Wallet.prototype._request = function (method, params = '') {
  * @type {Wallet}
  */
 
+// creates a new wallet
+Wallet.prototype.create_wallet = function(filename, password, language) {
+    let method = 'create_wallet';
+    let params = {
+        filename: filename || 'monero_wallet',
+        'password': password || '',
+        'language': language || 'English'
+    };
+    return this._request(method, params);
+};
+
+// open a wallet
+Wallet.prototype.open_wallet = function(filename, password) {
+    let method = 'open_wallet';
+    let params = {
+        filename: filename || 'monero_wallet',
+        'password': password || ''
+    };
+    return this._request(method, params);
+};
+
+// stops the wallet
+Wallet.prototype.stop_wallet = function() {
+    let method = 'stop_wallet';
+    return this._request(method);
+};
+
 // returns the wallet balance
 Wallet.prototype.balance = function() {
-    let method = 'getbalance';
-    return this._body(method);
+    let method = 'get_balance';
+    return this._request(method);
 };
 
 // return the wallet address
 Wallet.prototype.address = function() {
-    let method = 'getaddress';
-    return this._body(method);
+    let method = 'get_address';
+    return this._request(method);
 };
 
 // transfer Monero to a single recipient, or a group of recipients

--- a/lib/wallet.js
+++ b/lib/wallet.js
@@ -1,64 +1,35 @@
 'use strict';
-var http = require('http');
+var request = require('request-promise');
 
 class Wallet {
-    constructor(hostname, port) {
+    constructor(hostname, port, user, pass) {
         this.hostname = hostname || '127.0.0.1';
         this.port = port || 18082;
+        this.user = user || '';
+        this.pass = pass || '';
+
+        this._request('get_balance'); // This line is necessary in order to do the initial handshake between this wrapper and monero-wallet-rpc; without it, the first request to the wrapper fails (subsequent request succeed, though.)
     }
 }
 
 // general API wallet request
-Wallet.prototype._request = function (body) {
-    // encode the request into JSON
-    let requestJSON = JSON.stringify(body);
-
-    // set basic headers
-    let headers = {};
-    headers['Content-Type'] = 'application/json';
-    headers['Content-Length'] = Buffer.byteLength(requestJSON, 'utf8');
-
-    // make a request to the wallet
+Wallet.prototype._request = function (method, params = '') {
     let options = {
-        hostname: this.hostname,
-        port: this.port,
-        path: '/json_rpc',
-        method: 'POST',
-        headers: headers
+        forever: true,
+        json: {'jsonrpc': '2.0', 'id': '0', 'method': method}
     };
-    let requestPromise = new Promise((resolve, reject) => {
-        let data = '';
-        let req = http.request(options, (res) => {
-            res.setEncoding('utf8');
-            res.on('data', (chunk) => { data += chunk; });
-            res.on('end', function() {
-                let body = JSON.parse(data);
-                if(body && body.result) {
-                    resolve(body.result);
-                } else if (body && body.error) {
-                    resolve(body.error);
-                } else {
-                    resolve('Wallet response error. Please try again.');
-                }
-            });
-        });
-        req.on('error', (e) => resolve(e));
-        req.write(requestJSON);
-        req.end();
-    });
 
-    return requestPromise;
-};
-
-// build request body
-Wallet.prototype._body = function (method, params) {
-    let body = {
-        jsonrpc: '2.0',
-        id: '0',
-        method: method,
-        params: params
-    };
-    return this._request(body);
+    if (params) {
+        options['json']['params'] = params;
+    }
+    if (this.user) {
+        options['auth'] = {
+            'user': this.user,
+            'pass': this.pass,
+            'sendImmediately': false
+        }
+    }
+    return request.post(`http://${this.hostname}:${this.port}/json_rpc`, options);
 };
 
 /**

--- a/lib/wallet.js
+++ b/lib/wallet.js
@@ -29,7 +29,14 @@ Wallet.prototype._request = function (method, params = '') {
             'sendImmediately': false
         }
     }
-    return request.post(`http://${this.hostname}:${this.port}/json_rpc`, options);
+    return request.post(`http://${this.hostname}:${this.port}/json_rpc`, options)
+        .then((result) => {
+            if (result.hasOwnProperty('result')) {
+                return result.result;
+            } else {
+                return result;
+            }
+        });
 };
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,596 @@
+{
+  "name": "monero-nodejs",
+  "version": "4.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "ajv": {
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+      "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+      "requires": {
+        "co": "4.6.0",
+        "fast-deep-equal": "1.1.0",
+        "fast-json-stable-stringify": "2.0.0",
+        "json-schema-traverse": "0.3.1"
+      }
+    },
+    "asn1": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
+    },
+    "assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+    },
+    "aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+    },
+    "aws4": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+      "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+      "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+      "optional": true,
+      "requires": {
+        "tweetnacl": "0.14.5"
+      }
+    },
+    "bluebird": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
+    },
+    "boom": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
+      "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
+      "requires": {
+        "hoek": "4.2.1"
+      }
+    },
+    "caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+    },
+    "co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+    },
+    "combined-stream": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+      "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+      "requires": {
+        "delayed-stream": "1.0.0"
+      }
+    },
+    "commander": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
+      "integrity": "sha1-/UMOiJgy7DU7ms0d4hfBHLPu+HM=",
+      "dev": true
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "cryptiles": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
+      "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
+      "requires": {
+        "boom": "5.2.0"
+      },
+      "dependencies": {
+        "boom": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
+          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+          "requires": {
+            "hoek": "4.2.1"
+          }
+        }
+      }
+    },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "requires": {
+        "assert-plus": "1.0.0"
+      }
+    },
+    "debug": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+      "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+      "dev": true,
+      "requires": {
+        "ms": "0.7.1"
+      }
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
+    "diff": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
+      "integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8=",
+      "dev": true
+    },
+    "ecc-jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+      "optional": true,
+      "requires": {
+        "jsbn": "0.1.1"
+      }
+    },
+    "escape-string-regexp": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
+      "integrity": "sha1-Tbwv5nTnGUnK8/smlc5/LcHZqNE=",
+      "dev": true
+    },
+    "extend": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+    },
+    "extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+    },
+    "fast-deep-equal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+    },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+    },
+    "form-data": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+      "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+      "requires": {
+        "asynckit": "0.4.0",
+        "combined-stream": "1.0.6",
+        "mime-types": "2.1.18"
+      }
+    },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "requires": {
+        "assert-plus": "1.0.0"
+      }
+    },
+    "glob": {
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+      "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3",
+        "minimatch": "0.3.0"
+      }
+    },
+    "growl": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
+      "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
+      "dev": true
+    },
+    "har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+    },
+    "har-validator": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+      "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+      "requires": {
+        "ajv": "5.5.2",
+        "har-schema": "2.0.0"
+      }
+    },
+    "hawk": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
+      "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
+      "requires": {
+        "boom": "4.3.1",
+        "cryptiles": "3.1.2",
+        "hoek": "4.2.1",
+        "sntp": "2.1.0"
+      }
+    },
+    "hoek": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
+      "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
+    },
+    "http-signature": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "jsprim": "1.4.1",
+        "sshpk": "1.14.1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+    },
+    "jade": {
+      "version": "0.26.3",
+      "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
+      "integrity": "sha1-jxDXl32NefL2/4YqgbBRPMslaGw=",
+      "dev": true,
+      "requires": {
+        "commander": "0.6.1",
+        "mkdirp": "0.3.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
+          "integrity": "sha1-+mihT2qUXVTbvlDYzbMyDp47GgY=",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
+          "integrity": "sha1-G79asbqCevI1dRQ0kEJkVfSB/h4=",
+          "dev": true
+        }
+      }
+    },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "optional": true
+    },
+    "json-schema": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+    },
+    "json-schema-traverse": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+    },
+    "jsprim": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
+      }
+    },
+    "lodash": {
+      "version": "4.17.5",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+      "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+    },
+    "lru-cache": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+      "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
+      "dev": true
+    },
+    "mime-db": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+      "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
+    },
+    "mime-types": {
+      "version": "2.1.18",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+      "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+      "requires": {
+        "mime-db": "1.33.0"
+      }
+    },
+    "minimatch": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+      "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
+      "dev": true,
+      "requires": {
+        "lru-cache": "2.7.3",
+        "sigmund": "1.0.1"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      }
+    },
+    "mocha": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-2.5.3.tgz",
+      "integrity": "sha1-FhvlvetJZ3HrmzV0UFC2IrWu/Fg=",
+      "dev": true,
+      "requires": {
+        "commander": "2.3.0",
+        "debug": "2.2.0",
+        "diff": "1.4.0",
+        "escape-string-regexp": "1.0.2",
+        "glob": "3.2.11",
+        "growl": "1.9.2",
+        "jade": "0.26.3",
+        "mkdirp": "0.5.1",
+        "supports-color": "1.2.0",
+        "to-iso-string": "0.0.2"
+      }
+    },
+    "ms": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+      "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
+      "dev": true
+    },
+    "oauth-sign": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
+    },
+    "performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+    },
+    "punycode": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+    },
+    "qs": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+      "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
+    },
+    "request": {
+      "version": "2.85.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.85.0.tgz",
+      "integrity": "sha512-8H7Ehijd4js+s6wuVPLjwORxD4zeuyjYugprdOXlPSqaApmL/QOy+EB/beICHVCHkGMKNh5rvihb5ov+IDw4mg==",
+      "requires": {
+        "aws-sign2": "0.7.0",
+        "aws4": "1.6.0",
+        "caseless": "0.12.0",
+        "combined-stream": "1.0.6",
+        "extend": "3.0.1",
+        "forever-agent": "0.6.1",
+        "form-data": "2.3.2",
+        "har-validator": "5.0.3",
+        "hawk": "6.0.2",
+        "http-signature": "1.2.0",
+        "is-typedarray": "1.0.0",
+        "isstream": "0.1.2",
+        "json-stringify-safe": "5.0.1",
+        "mime-types": "2.1.18",
+        "oauth-sign": "0.8.2",
+        "performance-now": "2.1.0",
+        "qs": "6.5.1",
+        "safe-buffer": "5.1.1",
+        "stringstream": "0.0.5",
+        "tough-cookie": "2.3.4",
+        "tunnel-agent": "0.6.0",
+        "uuid": "3.2.1"
+      }
+    },
+    "request-promise": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/request-promise/-/request-promise-4.2.2.tgz",
+      "integrity": "sha1-0epG1lSm7k+O5qT+oQGMIpEZBLQ=",
+      "requires": {
+        "bluebird": "3.5.1",
+        "request-promise-core": "1.1.1",
+        "stealthy-require": "1.1.1",
+        "tough-cookie": "2.3.4"
+      }
+    },
+    "request-promise-core": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
+      "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
+      "requires": {
+        "lodash": "4.17.5"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+    },
+    "should": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/should/-/should-8.4.0.tgz",
+      "integrity": "sha1-XmCInT5kS73Tl6MM00+tKPz5C8A=",
+      "dev": true,
+      "requires": {
+        "should-equal": "0.8.0",
+        "should-format": "0.3.2",
+        "should-type": "0.2.0"
+      }
+    },
+    "should-equal": {
+      "version": "0.8.0",
+      "resolved": "http://registry.npmjs.org/should-equal/-/should-equal-0.8.0.tgz",
+      "integrity": "sha1-o/BXMv9FusG3ukEvhAiFaBlkEpk=",
+      "dev": true,
+      "requires": {
+        "should-type": "0.2.0"
+      }
+    },
+    "should-format": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/should-format/-/should-format-0.3.2.tgz",
+      "integrity": "sha1-pZgx4Bot3uFJkRvHFIvlyAMZ4f8=",
+      "dev": true,
+      "requires": {
+        "should-type": "0.2.0"
+      }
+    },
+    "should-type": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/should-type/-/should-type-0.2.0.tgz",
+      "integrity": "sha1-ZwfvlVKdmJ3MCY/gdTqx+RNrt/Y=",
+      "dev": true
+    },
+    "sigmund": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+      "dev": true
+    },
+    "sntp": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
+      "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
+      "requires": {
+        "hoek": "4.2.1"
+      }
+    },
+    "sshpk": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz",
+      "integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
+      "requires": {
+        "asn1": "0.2.3",
+        "assert-plus": "1.0.0",
+        "bcrypt-pbkdf": "1.0.1",
+        "dashdash": "1.14.1",
+        "ecc-jsbn": "0.1.1",
+        "getpass": "0.1.7",
+        "jsbn": "0.1.1",
+        "tweetnacl": "0.14.5"
+      }
+    },
+    "stealthy-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
+    },
+    "stringstream": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
+    },
+    "supports-color": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.0.tgz",
+      "integrity": "sha1-/x7R5hFp0Gs88tWI4YixjYhH4X4=",
+      "dev": true
+    },
+    "to-iso-string": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/to-iso-string/-/to-iso-string-0.0.2.tgz",
+      "integrity": "sha1-TcGeZk38y+Jb2NtQiwDG2hWCVdE=",
+      "dev": true
+    },
+    "tough-cookie": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
+      "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+      "requires": {
+        "punycode": "1.4.1"
+      }
+    },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "optional": true
+    },
+    "uuid": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
+      "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
+    },
+    "verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "1.3.0"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "monero-nodejs",
-  "version": "3.2.2",
-  "description": "a Node.js Monero wallet manager",
+  "version": "4.0.0",
+  "description": "A Monero library written in Node.js.",
   "main": "./lib/wallet.js",
   "scripts": {
     "test": "node_modules/.bin/mocha"
@@ -18,7 +18,7 @@
     "shapeshift",
     "cryptocurrency",
     "Node.js",
-    "simplewallet",
+    "monero-wallet-rpc",
     "bitcoin",
     "bitmonerod"
   ],
@@ -28,7 +28,10 @@
     "url": "https://github.com/PsychicCat/monero-nodejs/issues"
   },
   "homepage": "https://github.com/PsychicCat/monero-nodejs#readme",
-  "dependencies": {},
+  "dependencies": {
+    "request": "^2.85.0",
+    "request-promise": "^4.2.2"
+  },
   "devDependencies": {
     "mocha": "^2.4.5",
     "should": "^8.3.0"

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -2,13 +2,14 @@
 var moneroWallet = require('../lib/wallet');
 
 describe('moneroWallet', () => {
-    const Wallet = new moneroWallet('127.0.0.1', 28083, 'user', 'pass');
+    const Wallet = new moneroWallet('127.0.0.1', 28082, 'user', 'pass'); // Edit to match your own hostname, port, RPC username (if RPC login enabled,) and RPC password.
 
+    // Disabled these checks because users may access unique daemon hostname:port combinations.
     // describe('constructor', () => {
     //     it('should have default host set to `127.0.0.1`', () => {
     //         new moneroWallet().hostname.should.equal('127.0.0.1');
     //     });
-
+    //
     //     // it('should have default port set to 18082', () => {
     //     //     new moneroWallet().port.should.equal(18082);
     //     // });
@@ -16,8 +17,8 @@ describe('moneroWallet', () => {
 
     describe('methods', () => {
         describe('create_wallet()', () => {
-            it('should create a new wallet monero_wallet (if monero_wallet doesn\'t exist))', (done) => {
-                Wallet.create_wallet('asdasd').then(function(result){
+            it('should create a new wallet monero_wallet (if monero_wallet doesn\'t exist)', (done) => {
+                Wallet.create_wallet('monero_wallet').then(function(result){
                     if (result.hasOwnProperty('error')) {
                         if (result.hasOwnProperty('error')) {
                             if (result.error.code == -21) {
@@ -34,7 +35,7 @@ describe('moneroWallet', () => {
 
         describe('open_wallet()', () => {
             it('should open monero_wallet', (done) => {
-                Wallet.open_wallet().then(function(result){
+                Wallet.open_wallet('monero_wallet').then(function(result){
                     result.should.be.a.Object();
                     done();
                 })

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -25,7 +25,7 @@ describe('moneroWallet', () => {
                             }
                         }
                     } else {
-                        result.result.should.be.a.Object();
+                        result.should.be.a.Object();
                     }
                     done();
                 })
@@ -35,7 +35,7 @@ describe('moneroWallet', () => {
         describe('open_wallet()', () => {
             it('should open monero_wallet', (done) => {
                 Wallet.open_wallet().then(function(result){
-                    result.result.should.be.a.Object();
+                    result.should.be.a.Object();
                     done();
                 })
             })
@@ -44,7 +44,7 @@ describe('moneroWallet', () => {
         describe('balance()', () => {
             it('should retrieve the account balance', (done) => {
                 Wallet.balance().then(function(result){
-                    result.result.balance.should.be.a.Number();
+                    result.balance.should.be.a.Number();
                     done();
                 })
             })
@@ -53,7 +53,7 @@ describe('moneroWallet', () => {
         describe('address()', () => {
             it('should return the account address', (done) => {
                 Wallet.address().then(function(result){
-                    result.result.address.should.be.a.String();
+                    result.address.should.be.a.String();
                     done();
                 })
             })

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -2,23 +2,49 @@
 var moneroWallet = require('../lib/wallet');
 
 describe('moneroWallet', () => {
-    const Wallet = new moneroWallet();
+    const Wallet = new moneroWallet('127.0.0.1', 28083, 'user', 'pass');
 
-    describe('constructor', () => {
-        it('should have default host set to `127.0.0.1`', () => {
-            new moneroWallet().hostname.should.equal('127.0.0.1');
-        });
+    // describe('constructor', () => {
+    //     it('should have default host set to `127.0.0.1`', () => {
+    //         new moneroWallet().hostname.should.equal('127.0.0.1');
+    //     });
 
-        it('should have default port set to 18082', () => {
-            new moneroWallet().port.should.equal(18082);
-        });
-    });
+    //     // it('should have default port set to 18082', () => {
+    //     //     new moneroWallet().port.should.equal(18082);
+    //     // });
+    // });
 
     describe('methods', () => {
+        describe('create_wallet()', () => {
+            it('should create a new wallet monero_wallet (if monero_wallet doesn\'t exist))', (done) => {
+                Wallet.create_wallet('asdasd').then(function(result){
+                    if (result.hasOwnProperty('error')) {
+                        if (result.hasOwnProperty('error')) {
+                            if (result.error.code == -21) {
+                                result.error.code.should.be.equal(-21)
+                            }
+                        }
+                    } else {
+                        result.result.should.be.a.Object();
+                    }
+                    done();
+                })
+            })
+        })
+
+        describe('open_wallet()', () => {
+            it('should open monero_wallet', (done) => {
+                Wallet.open_wallet().then(function(result){
+                    result.result.should.be.a.Object();
+                    done();
+                })
+            })
+        })
+
         describe('balance()', () => {
             it('should retrieve the account balance', (done) => {
                 Wallet.balance().then(function(result){
-                    result.balance.should.be.a.Number();
+                    result.result.balance.should.be.a.Number();
                     done();
                 })
             })
@@ -27,7 +53,7 @@ describe('moneroWallet', () => {
         describe('address()', () => {
             it('should return the account address', (done) => {
                 Wallet.address().then(function(result){
-                    result.address.should.be.a.String();
+                    result.result.address.should.be.a.String();
                     done();
                 })
             })


### PR DESCRIPTION
This pull request adds optional RPC authentication, new wallet management methods create_wall and open_wallet, and differentiates the old sweep method into sweep_dust and sweep_all.

It also updates the documentation in README.md, the tests in test/index_test.js, and updates the major version in package.json to 4.0.0.  All authorship, donation addresses, etc. are left unchanged.

This pull request closes https://github.com/PsychicCat/monero-nodejs/issues/9 and https://github.com/PsychicCat/monero-nodejs/issues/14