### PR TITLE
Add openWallet method

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,27 @@ To run the tests, clone the repository and then:
 
 ## Wallet Methods
 
+### openWallet
+Usage:
+
+```
+wallet.openWallet(filename, password);
+```
+
+Opens a wallet file.  Returns an empty object if successful.  Used when monero-wallet-rpc is started without a wallet file specified.
+
+Example response:
+
+```
+{}
+```
+
+Example error response:
+
+```
+{ code: -1, message: 'Failed to open wallet' }
+```
+
 ### balance
 Usage:
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,12 @@ Parameters:
         {   
             mixin: (*number*), // amount of existing transaction outputs to mix yours with (default is 4)
             unlockTime: (*number*), // number of blocks before tx is spendable (default is 0)
-            pid: (*string*) // optional payment ID (a 64 character hexadecimal string used for identifying the sender of a payment) 
+            pid: (*string*) // optional payment ID (a 64 character hexadecimal string used for identifying the sender of a payment)
+            payment_id: (*string*) // optional payment ID (a 64 character hexadecimal string used for identifying the sender of a payment)
+            do_not_relay: (*boolean*) // optional boolean used to indicate whether a transaction should be relayed or not
+            priority: (*integer*) // optional transaction priority
+            get_tx_hex: (*boolean*) // optional boolean used to indicate that the transaction should be returned as hex string after sending
+            get_tx_key: (*boolean*) // optional boolean used to indicate that the transaction key should be returned after sending
         }
 
 Example response:

--- a/README.md
+++ b/README.md
@@ -73,6 +73,11 @@ wallet.openWallet(filename, password);
 
 Opens a wallet file.  Returns an empty object if successful.  Used when monero-wallet-rpc is started without a wallet file specified.
 
+Parameters:
+
+* `filename` - Filename of wallet file to open (*string*)
+* `password` - Password of wallet file to open (*string*)
+
 Example response:
 
 ```

--- a/lib/wallet.js
+++ b/lib/wallet.js
@@ -66,6 +66,16 @@ Wallet.prototype._body = function (method, params) {
  * @type {Wallet}
  */
 
+// open a wallet
+Wallet.prototype.openWallet = function(filename, password) {
+    let method = 'open_wallet';
+    let params = {
+        filename: filename || 'monero_wallet',
+        password: password || ''
+    };
+    return this._body(method, params);
+};
+
 // returns the wallet balance
 Wallet.prototype.balance = function() {
     let method = 'getbalance';


### PR DESCRIPTION
Useful if `monero-wallet-rpc` has been launched with the `--wallet-dir` option