### PR TITLE
Fixed rejected promise while digest authentication

### DIFF
--- a/lib/wallet.js
+++ b/lib/wallet.js
@@ -16,6 +16,7 @@ class Wallet {
 Wallet.prototype._request = function (method, params = '') {
     let options = {
         forever: true,
+        simple: false, // to avoid promise rejections while trying digest auth.
         json: {'jsonrpc': '2.0', 'id': '0', 'method': method}
     };
 


### PR DESCRIPTION
Probably this problem happens only for new (0.12.0.0+) versions of monero-wallet-rpc.