### PR TITLE
Proper fix for digest auth

### DIFF
--- a/lib/wallet.js
+++ b/lib/wallet.js
@@ -1,5 +1,6 @@
 'use strict';
-var request = require('request-promise');
+const request = require('request-promise');
+const http = require('http');
 
 class Wallet {
     constructor(hostname, port, user, pass) {
@@ -16,7 +17,11 @@ class Wallet {
 Wallet.prototype._request = function (method, params = '') {
     let options = {
         forever: true,
-        json: {'jsonrpc': '2.0', 'id': '0', 'method': method}
+        json: {'jsonrpc': '2.0', 'id': '0', 'method': method},
+        agent: new http.Agent({
+            keepAlive: true,
+            maxSockets: 1
+        })
     };
 
     if (params) {


### PR DESCRIPTION
For monero-wallet-rpc as of v0.12.0.0, this library occasionally fails the digest auth. This is because monero-wallet-rpc expects both requests (first, unathenticated and second, with "Authorization" header) for digest auth to occur in **exactly same** TCP session. This can be done by using custom HTTP Agent.

https://nodejs.org/docs/latest/api/http.html#http_class_http_agent
https://stackoverflow.com/questions/10895901/how-to-send-consecutive-requests-with-http-keep-alive-in-node-js